### PR TITLE
Fix CI failures: correct import path for Fly sensitivity models and deprecation warnings

### DIFF
--- a/scidoggo/circuit_models/chromatic.py
+++ b/scidoggo/circuit_models/chromatic.py
@@ -50,7 +50,7 @@ def calc_log_excitation(wls, s_filter, i_spectrum, b_spectrum=None):
 
 
 class PhotoreceptorAdaptation(PyroModule):
-    """
+    r"""
     Photoreceptor Adaptation model
 
     .. math::
@@ -79,7 +79,7 @@ class PhotoreceptorAdaptation(PyroModule):
 
 
 class NoiseThresholdedPrAdaptation(PyroModule):
-    """
+    r"""
     Noise thresholded photoreceptor adaptation:
 
     .. math::

--- a/scidoggo/circuit_models/chromatic_priors.py
+++ b/scidoggo/circuit_models/chromatic_priors.py
@@ -20,8 +20,6 @@ from .chromatic import (
 from .interp1d import Interp1d
 from .pyro_components import FLOAT_TYPE
 
-interp1d = Interp1d()
-
 
 class FlyStavenga1993SensitivityModel(Stavenga1993SensitivityModel):
     """
@@ -152,5 +150,5 @@ class InterpolateSumMeasurement(MeasurementConversion):
             # (wavlengths x samples).T
             # clamp spectrum to zero
             # get new y array
-            spectrum += torch.relu(interp1d(moutput, measurement, output)).T
+            spectrum += torch.relu(Interp1d.apply(moutput, measurement, output)).T
         return spectrum

--- a/scidoggo/circuit_models/model_constructors/nln_chromatic.py
+++ b/scidoggo/circuit_models/model_constructors/nln_chromatic.py
@@ -6,9 +6,11 @@ import pyro.distributions as dist
 
 from ..chromatic import (
     ChromaticEncodingModel,
+    NoiseThresholdedPrAdaptation,
+)
+from ..chromatic_priors import (
     FlyStavenga1993InnerSensitivityModel,
     FlyStavenga1993SensitivityModel,
-    NoiseThresholdedPrAdaptation,
 )
 from ..gaussian import GaussianObsEncodingModel
 from ..lnl import LnlModel


### PR DESCRIPTION
- nln_chromatic.py: import FlyStavenga1993{Inner,}SensitivityModel from
  chromatic_priors (where they are defined) instead of chromatic (which
  would require a circular import to re-export them)
- chromatic.py: use raw docstrings on classes with LaTeX math to silence
  DeprecationWarning for invalid escape sequence '\l'
- chromatic_priors.py: remove module-level Interp1d() instantiation and
  call Interp1d.apply() directly, silencing PyTorch autograd deprecation
  warning

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L5kd1U7e5XzfwUZjBVrWBV